### PR TITLE
Fix git link from yale-img to yale-sean

### DIFF
--- a/scripts/checkout.sh
+++ b/scripts/checkout.sh
@@ -5,7 +5,7 @@ set -x
 
 mkdir -p src
 pushd src
-git clone git@github.com:yale-img/social_sim_ros social_sim_ros
+git clone git@github.com:yale-sean/social_sim_ros social_sim_ros
 pushd social_sim_ros
 git submodule update --init --recursive
 popd


### PR DESCRIPTION
I had to change this locally as this repo doesn't exist on yale-img's account. I assume it once did but has now migrated over here. If this is wrong please lmk.